### PR TITLE
Add binder support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# principled-bayesian-workflow-pymc3
+# Principled Bayesian Workflow in PyMC3
+
 A PyMC3 translation of Michael Betancourt's "A Principled Bayesian Workflow"
 
-[Original Code](https://github.com/betanalpha/knitr_case_studies/tree/master/principled_bayesian_workflow)
+[![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/lstmemery/principled-bayesian-workflow-pymc3/master)
+[![nbviewer](https://img.shields.io/badge/view%20on-nbviewer-brightgreen.svg)](http://nbviewer.jupyter.org/github/lstmemery/principled-bayesian-workflow-pymc3/tree/master/)
 
-[Original Case Study](https://betanalpha.github.io/assets/case_studies/principled_bayesian_workflow.html)
+- [Original Code](https://github.com/betanalpha/knitr_case_studies/tree/master/principled_bayesian_workflow)
+- [Original Case Study](https://betanalpha.github.io/assets/case_studies/principled_bayesian_workflow.html)

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,0 +1,5 @@
+pymc3
+pandas
+scipy
+seaborn
+theano


### PR DESCRIPTION
This makes the notebooks more interactive by [Binderizing the repo](https://mybinder.org/).

Given the imports in the notebooks, this adds a `requirements.txt` that Binder looks for as a `binder` directory exists and then builds an image with those. To get a feel for what this will look like, check out the Binderized version of my fork by clicking this badge: [![Binder](https://mybinder.org/badge.svg)](https://mybinder.org/v2/gh/matthewfeickert/principled-bayesian-workflow-pymc3/feature/add-Binder-support)

This also adds some badges to the `README`.